### PR TITLE
Disabled styling and eslint configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,64 @@
+module.exports = {        
+  "parser": "babel-eslint",
+  "extends": "airbnb",
+  "rules": {
+    "linebreak-style": ["error", process.platform === 'win32' ? 'windows': 'unix'], // allow Windows-style line endings on Windows platform, git should commit Unix-style
+    "max-len": [
+      2,
+      {
+        "code": 150,
+        "tabWidth": 2,
+        "ignoreUrls": true
+      }
+    ],
+    "react/prefer-stateless-function": 0,
+    "react/forbid-prop-types": 0,
+    "react/jsx-filename-extension": 0,
+    "react/destructuring-assignment": 0,
+    "react/jsx-one-expression-per-line": 0,
+    "react/jsx-props-no-spreading": 0,
+    "jsx-a11y/anchor-is-valid": 0,
+    "jsx-a11y/click-events-have-key-events": 0,
+    "jsx-a11y/label-has-associated-control": [
+      2,
+      {
+        "labelAttributes": [
+          "label"
+        ],
+        "depth": 3
+      }
+    ],
+    "jsx-a11y/label-has-for": 0
+  },
+  "overrides": [
+    {
+      "files": [
+        "*.stories.js"
+      ],
+      "rules": {
+        "import/no-extraneous-dependencies": "off",
+        "import/no-webpack-loader-syntax": "off",
+        "import/no-unresolved": "off",
+        "global-require": "off"
+      }
+    },
+    {
+      "files": [
+        "src/[A-Z]*/index.js"
+      ],
+      "rules": {
+        "import/prefer-default-export": "off"
+      }
+    },
+    {
+      "files": "examples/**/*.js",
+      "rules": {
+        "import/no-unresolved": "off"
+      }
+    }
+  ],
+  "env": {
+    "browser": true,
+    "node": true
+  }
+};

--- a/package.json
+++ b/package.json
@@ -18,69 +18,6 @@
       "pre-commit": "npm test"
     }
   },
-  "eslintConfig": {
-    "parser": "babel-eslint",
-    "extends": "airbnb",
-    "rules": {
-      "max-len": [
-        2,
-        {
-          "code": 150,
-          "tabWidth": 2,
-          "ignoreUrls": true
-        }
-      ],
-      "react/prefer-stateless-function": 0,
-      "react/forbid-prop-types": 0,
-      "react/jsx-filename-extension": 0,
-      "react/destructuring-assignment": 0,
-      "react/jsx-one-expression-per-line": 0,
-      "react/jsx-props-no-spreading": 0,
-      "jsx-a11y/anchor-is-valid": 0,
-      "jsx-a11y/click-events-have-key-events": 0,
-      "jsx-a11y/label-has-associated-control": [
-        2,
-        {
-          "labelAttributes": [
-            "label"
-          ],
-          "depth": 3
-        }
-      ],
-      "jsx-a11y/label-has-for": 0
-    },
-    "overrides": [
-      {
-        "files": [
-          "*.stories.js"
-        ],
-        "rules": {
-          "import/no-extraneous-dependencies": "off",
-          "import/no-webpack-loader-syntax": "off",
-          "import/no-unresolved": "off",
-          "global-require": "off"
-        }
-      },
-      {
-        "files": [
-          "src/[A-Z]*/index.js"
-        ],
-        "rules": {
-          "import/prefer-default-export": "off"
-        }
-      },
-      {
-        "files": "examples/**/*.js",
-        "rules": {
-          "import/no-unresolved": "off"
-        }
-      }
-    ],
-    "env": {
-      "browser": true,
-      "node": true
-    }
-  },
   "browserslist": [
     ">0.2%",
     "ie >= 10"

--- a/src/Button/Button.scss
+++ b/src/Button/Button.scss
@@ -3,6 +3,7 @@
 $dangerColor: #e5243b;
 $darkDangerColor: #890303;
 $ctaColor: #008566;
+$disabledColor: #cccccc;
 
 .dfo-button {
   font-size: 1.8rem;
@@ -29,6 +30,12 @@ $ctaColor: #008566;
     background-color: $secondary;
     border-color: $secondary;
     color: $background;
+  }
+
+  &:disabled {
+    background-color: $disabledColor;
+    border-color: $disabledColor;
+    cursor: default;
   }
 
   &--danger {

--- a/src/Button/Button.stories.js
+++ b/src/Button/Button.stories.js
@@ -71,4 +71,15 @@ storiesOf('Button', module)
       </Button>
     ),
     options,
+  )
+  .add(
+    'Disabled',
+    () => (
+      <div>
+        <Button onClick={action('clicked')} disabled>
+          {text('Text', 'Sign up for our newsletter')}
+        </Button>
+      </div>
+    ),
+    options,
   );

--- a/src/Input/Input.scss
+++ b/src/Input/Input.scss
@@ -1,5 +1,8 @@
 @import "../../sass/base/index";
 
+$disabledColor: #dddddd;
+$disabledBorderColor: #aaaaaa;
+
 .dfo-input {
   width: 100%;
   font-size: 1.8rem;
@@ -31,6 +34,12 @@
   label:focus {
     appearance: none;
     box-shadow: inset 0 0 0 1px $primaryLight;
+  }
+
+  input:disabled {
+    border-color: $disabledBorderColor;
+    background-color: $disabledColor;
+    box-shadow: none;
   }
 
   .dfo-error-wrapper {

--- a/src/Input/Input.stories.js
+++ b/src/Input/Input.stories.js
@@ -42,4 +42,22 @@ storiesOf('Text field', module)
       Error
       `,
     },
+  )
+  .add(
+    'disabled',
+    () => (
+      <div style={{ maxWidth: '705px' }}>
+        <Input
+          label={text('label', 'Fornavn:')}
+          name={text('name', 'firstName')}
+          type="text"
+          disabled
+        />
+      </div>
+    ),
+    {
+      /* eslint-disable import/no-webpack-loader-syntax */
+      css: require('!to-string-loader!css-loader!sass-loader?outputStyle=compressed!../Input/Input.scss'),
+      /* eslint-enable import/no-webpack-loader-syntax */
+    },
   );


### PR DESCRIPTION
- Added disabled styling for the Input component and the Button component. 
- Moved eslint configuration to js file in order to allow CRLF on the Windows platform. Git should take care of committing Unix style (LF).